### PR TITLE
Include test.json in extra-source-files

### DIFF
--- a/buffer-builder.cabal
+++ b/buffer-builder.cabal
@@ -47,7 +47,7 @@ build-type:          Simple
 stability:           experimental
 homepage:            https://github.com/chadaustin/buffer-builder
 cabal-version:       >=1.10
-extra-source-files:  test/*.hs changelog.md
+extra-source-files:  test/*.hs test.json changelog.md
 
 library
   exposed-modules:


### PR DESCRIPTION
Without it, `cabal sdist` doesn't include it in the tarball that gets uploaded to Hackage, which causes the benchmarks to fail when obtained from Hackage:

```
Benchmark json-bench: RUNNING...
json-bench: test.json: openBinaryFile: does not exist (No such file or directory)
Benchmark json-bench: ERROR
```

See also https://github.com/iu-parfunc/sc-haskell/issues/7
