### PR TITLE
Add 'stdc++' as an explicit library dependency.

### DIFF
--- a/buffer-builder.cabal
+++ b/buffer-builder.cabal
@@ -70,6 +70,7 @@ library
   c-sources: cbits/buffer.cpp cbits/branchlut.cpp
   install-includes: cbits/branchlut.h
   cc-options: -O2 -Wall
+  extra-libraries: stdc++
 
 test-suite tests
   type: exitcode-stdio-1.0


### PR DESCRIPTION
This is necessary on some systems to ensure that dynamic linking
works properly at Template Haskell time.