### PR TITLE
Add semigroups dependency for old compilers

### DIFF
--- a/buffer-builder.cabal
+++ b/buffer-builder.cabal
@@ -61,6 +61,9 @@ library
                , text
                , vector
                , unordered-containers
+               
+  if !impl(ghc >= 8.0)
+    build-depends: semigroups
 
   default-language: Haskell2010
   ghc-options: -O2 -Wall


### PR DESCRIPTION
It's somewhat heavy but I guess it's better than the alternative of not building.

Related to #16.